### PR TITLE
feat: enable MongoDB 5.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM percona/percona-server-mongodb:4.4
+FROM percona/percona-server-mongodb:5.0
 LABEL edu.uky.cs.netrecon.parse-hipaa.vendor="Network Reconnaissance Lab"
 LABEL edu.uky.cs.netrecon.parse-hipaa.authors="baker@cs.uky.edu"
 LABEL description="HIPAA & GDPR compliant ready Mongo Database with percona-server."

--- a/Singularity
+++ b/Singularity
@@ -1,5 +1,5 @@
 Bootstrap: docker
-From: netreconlab/hipaa-mongo:latest
+From: netreconlab/hipaa-mongo:5.0
 
 %runscript
 echo "Successfully built singularity from docker!"


### PR DESCRIPTION
The `5.0` and `6.0` images for Percona-server-mongogb have a script error, so hipaa-mongo cannot be upgraded past 4.4 until those errors are fixed on Percona's side.

Close #3 